### PR TITLE
This change makes bcrypt_nif thread safe

### DIFF
--- a/c_src/bcrypt_nif.c
+++ b/c_src/bcrypt_nif.c
@@ -75,7 +75,7 @@ static ERL_NIF_TERM hashpw(task_t* task)
 {
     char password[1024] = { 0 };
     char salt[1024] = { 0 };
-    char *ret = NULL;
+    char encrypted[1024] = { 0 };
 
     size_t password_sz = 1024;
     if (password_sz > task->data.hash.password.size)
@@ -87,7 +87,7 @@ static ERL_NIF_TERM hashpw(task_t* task)
         salt_sz = task->data.hash.salt.size;
     (void)memcpy(&salt, task->data.hash.salt.data, salt_sz);
 
-    if (NULL == (ret = bcrypt(password, salt)) || 0 == strcmp(ret, ":")) {
+    if (bcrypt(encrypted, password, salt)) {
         return enif_make_tuple3(
             task->env,
             enif_make_atom(task->env, "error"),
@@ -99,7 +99,7 @@ static ERL_NIF_TERM hashpw(task_t* task)
         task->env,
         enif_make_atom(task->env, "ok"),
         task->ref,
-        enif_make_string(task->env, ret, ERL_NIF_LATIN1));
+        enif_make_string(task->env, encrypted, ERL_NIF_LATIN1));
 }
 
 void* async_worker(void* arg)

--- a/c_src/bcrypt_nif.c
+++ b/c_src/bcrypt_nif.c
@@ -134,6 +134,7 @@ static ERL_NIF_TERM bcrypt_encode_salt(ErlNifEnv* env, int argc, const ERL_NIF_T
 {
     ErlNifBinary csalt, bin;
     unsigned long log_rounds;
+    ERL_NIF_TERM ret;
 
     if (!enif_inspect_binary(env, argv[0], &csalt) || 16 != csalt.size) {
         return enif_make_badarg(env);
@@ -152,7 +153,9 @@ static ERL_NIF_TERM bcrypt_encode_salt(ErlNifEnv* env, int argc, const ERL_NIF_T
     encode_salt((char *)bin.data, (u_int8_t*)csalt.data, csalt.size, log_rounds);
     enif_release_binary(&csalt);
 
-    return enif_make_string(env, (char *)bin.data, ERL_NIF_LATIN1);
+    ret = enif_make_string(env, (char *)bin.data, ERL_NIF_LATIN1);
+    enif_release_binary(&bin);
+    return ret;
 }
 
 static ERL_NIF_TERM bcrypt_hashpw(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])

--- a/c_src/bcrypt_nif.h
+++ b/c_src/bcrypt_nif.h
@@ -5,7 +5,7 @@
 
 typedef unsigned char byte;
 
-char *bcrypt(const char *, const char *);
+int bcrypt(char *, const char *, const char *);
 void encode_salt(char *, u_int8_t *, u_int16_t, u_int8_t);
 
 typedef struct {


### PR DESCRIPTION
Without it, multiple threads calling to bcrypt_nif can result in bad hashes coming back. If you're lucky, you'll get nulls in unexpected places and attempts to verify the hash will get a bcrypt failure; if you're not, you'll get a syntactically valid but incorrect hash back.

I'm using bcyrpt_nif directly, not using the worker interface. If you're using the worker interface you should be OK, because it only does one bcrypt at a time.
