### PR TITLE
Use crypto:strong_rand_bytes/1 instead of crypto:rand_bytes/1

### DIFF
--- a/src/bcrypt_nif.erl
+++ b/src/bcrypt_nif.erl
@@ -54,7 +54,7 @@ init() ->
 %%--------------------------------------------------------------------
 gen_salt(LogRounds)
   when is_integer(LogRounds), LogRounds < 32, LogRounds > 3 ->
-    R = crypto:rand_bytes(16),
+    R = crypto:strong_rand_bytes(16),
     encode_salt(R, LogRounds).
 
 encode_salt(_R, _LogRounds) ->

--- a/src/bcrypt_port.erl
+++ b/src/bcrypt_port.erl
@@ -39,11 +39,11 @@ start_link() ->
 stop() -> gen_server:call(?MODULE, stop).
 
 gen_salt(Pid) ->
-    R = crypto:rand_bytes(16),
+    R = crypto:strong_rand_bytes(16),
     gen_server:call(Pid, {encode_salt, R}, infinity).
 
 gen_salt(Pid, LogRounds) ->
-    R = crypto:rand_bytes(16),
+    R = crypto:strong_rand_bytes(16),
     gen_server:call(Pid, {encode_salt, R, LogRounds}, infinity).
 
 hashpw(Pid, Password, Salt) ->


### PR DESCRIPTION
`crypto:rand_bytes/1` has been deprecated in newer versions of erlang. This PR replace the calls to `crypto:rand_bytes/1` with `crypto:strong_rand_bytes/1`.

This will probably break the compatibility with older versions of Erlang. If needed I can update this PR to favor `crypto:strong_rand_bytes/1` and, if not available, fallback on `crypto:rand_bytes/1`.

Also from the [doc](http://erlang.org/documentation/doc-8.3/lib/crypto-3.7.3/doc/html/crypto.html#strong_rand_bytes-1), `crypto:strong_rand_bytes/1` can throw a `low_entropy` exception. I have far from an expert in this field, so if you have any comment or recommendation, please let me know.