### PR TITLE
To build it by Erlang/OTP 20

### DIFF
--- a/src/bcrypt_nif.erl
+++ b/src/bcrypt_nif.erl
@@ -54,7 +54,7 @@ init() ->
 %%--------------------------------------------------------------------
 gen_salt(LogRounds)
   when is_integer(LogRounds), LogRounds < 32, LogRounds > 3 ->
-    R = crypto:rand_bytes(16),
+    R = crypto:strong_rand_bytes(16),
     encode_salt(R, LogRounds).
 
 encode_salt(_R, _LogRounds) ->

--- a/src/bcrypt_port.erl
+++ b/src/bcrypt_port.erl
@@ -39,11 +39,11 @@ start_link() ->
 stop() -> gen_server:call(?MODULE, stop).
 
 gen_salt(Pid) ->
-    R = crypto:rand_bytes(16),
+    R = crypto:strong_rand_bytes(16),
     gen_server:call(Pid, {encode_salt, R}, infinity).
 
 gen_salt(Pid, LogRounds) ->
-    R = crypto:rand_bytes(16),
+    R = crypto:strong_rand_bytes(16),
     gen_server:call(Pid, {encode_salt, R, LogRounds}, infinity).
 
 hashpw(Pid, Password, Salt) ->


### PR DESCRIPTION
I've modified some sources to build it by Erlang/OTP 20 because `crypto:rand_bytes/1` was removed from Erlang/OTP 20.